### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,7 +15,7 @@ SoftwareI2C	KEYWORD1
 begin	KEYWORD2
 beginTransmission	KEYWORD2
 endTransmission	KEYWORD2
-setClock KEYWORD2
+setClock	KEYWORD2
 end	KEYWORD2
 write	KEYWORD2
 requestFrom	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords